### PR TITLE
Add Paubox Forms API support and update documentation (v1.3)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,11 @@
-Revision history for Perl module Paubox_Email_SDK
+Revision history for Perl module Paubox_Email_SDK / Paubox_Forms_SDK
+
+1.3 2024-01-01
+
+    - Added Paubox_Forms_SDK module with getForm and submitForm methods.
+
+    - Updated ApiHelper to conditionally set Authorization header,
+      enabling use with public (no-auth) Forms API endpoints.
 
 1.2 2019-07-01
     

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ make test
 - Methods: `sendMessage`, `getEmailDisposition`
 
 ### Forms API (`Paubox_Forms_SDK`)
-- Base URL: `https://next.paubox.com`
+- Base URL: `https://apx.paubox.com/forms`
 - Auth: None (public endpoints)
 - Methods: `getForm`, `submitForm`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# Paubox Perl SDK
+
+Official Perl SDK for the Paubox Email API and Paubox Forms API.
+
+## Repository Structure
+
+```
+lib/
+  Paubox_Email_SDK.pm          # Email API: sendMessage, getEmailDisposition
+  Paubox_Email_SDK/
+    ApiHelper.pm               # HTTP layer (REST::Client GET/POST)
+    Message.pm                 # Email message object
+  Paubox_Forms_SDK.pm          # Forms API: getForm, submitForm
+t/
+  Paubox_Email_SDK.t           # Test runner entry point
+  SendMessage_TestData.csv     # CSV-driven test data for email tests
+  lib/
+    Paubox_Email_SDK/Test.pm   # Email API test cases (Test::Class)
+    Paubox_Forms_SDK/Test.pm   # Forms API test cases (Test::Class)
+Makefile.PL                    # CPAN build config
+cpanfile                       # Perl dependency declarations
+CHANGES                        # Changelog
+```
+
+## Setup
+
+### Install dependencies
+
+```bash
+cpanm --installdeps .
+```
+
+Or install from `cpanfile` directly:
+
+```bash
+cpanm JSON Config::General REST::Client TryCatch String::Util MIME::Base64
+cpanm Test::Class Test::More Text::CSV
+```
+
+### Configure credentials (Email API only)
+
+Create `config.cfg` in the project root:
+
+```
+API_KEY = YOUR_API_KEY
+API_USERNAME = YOUR_ENDPOINT_NAME
+```
+
+The Forms API is public and does not require credentials.
+
+## Running Tests
+
+```bash
+perl Makefile.PL
+make test
+```
+
+## Key Architecture Patterns
+
+- **HTTP layer:** All requests go through `Paubox_Email_SDK::ApiHelper`, which wraps `REST::Client`. Both `getForm`/`submitForm` and email methods reuse this helper; Forms calls pass an empty auth header which is now conditionally omitted.
+- **Error handling:** `TryCatch` is used throughout; methods die on unexpected responses.
+- **JSON:** All request bodies are `encode_json` encoded; responses are parsed with `from_json` / `decode_json`.
+- **Base64:** HTML email content is base64-encoded before transmission (`MIME::Base64`). Form attachment content must also be base64-encoded by the caller.
+- **Config:** Email credentials are read from `config.cfg` using `Config::General`. No config file is needed for the Forms SDK.
+
+## APIs
+
+### Email API (`Paubox_Email_SDK`)
+- Base URL: `https://api.paubox.net/v1/{apiUsername}`
+- Auth: `Token token=<apiKey>`
+- Methods: `sendMessage`, `getEmailDisposition`
+
+### Forms API (`Paubox_Forms_SDK`)
+- Base URL: `https://next.paubox.com`
+- Auth: None (public endpoints)
+- Methods: `getForm`, `submitForm`
+
+See [api.md](api.md) for full API reference.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The Paubox Email API allows your application to send secure, HIPAA compliant ema
 
 # Table of Contents
 * [Installation](#installation)
-*  [Usage](#usage)
-*  [Contributing](#contributing)
-*  [License](#license)
+* [Usage](#usage)
+  * [Email API](#email-api)
+  * [Forms API](#forms-api)
+* [Contributing](#contributing)
+* [License](#license)
 
 <a name="#installation"></a>
 ## Installation
@@ -46,6 +48,9 @@ echo "config.cfg" >> .gitignore
 
 <a name="#usage"></a>
 ## Usage
+
+<a name="#email-api"></a>
+### Email API
 
 To send an email, prepare a Message object and call the sendMessage method of Paubox_Email_SDK.
 
@@ -157,6 +162,64 @@ use Paubox_Email_SDK;
 my $service = Paubox_Email_SDK -> new();
 my $response = $service -> getEmailDisposition("SOURCE_TRACKING_ID");
 print $response;
+```
+
+<a name="#forms-api"></a>
+### Forms API
+
+The Paubox Forms API lets you retrieve form definitions and submit responses. These
+endpoints are **public** — no API key or `config.cfg` is required.
+
+#### Retrieving a form
+
+```perl
+use strict;
+use warnings;
+use Paubox_Forms_SDK;
+
+my $forms = Paubox_Forms_SDK->new();
+my $response = $forms->getForm("your-form-uuid");
+print $response;
+# Returns JSON with id, title, form_html, form_json, form_css, etc.
+```
+
+#### Submitting a form response
+
+```perl
+use strict;
+use warnings;
+use Paubox_Forms_SDK;
+
+my $forms = Paubox_Forms_SDK->new();
+my $response = $forms->submitForm(
+    "your-form-uuid",
+    { first_name => "Jane", last_name => "Doe", email => "jane\@example.com" }
+);
+# Returns empty body on success (HTTP 201)
+```
+
+#### Submitting a form response with attachments
+
+Attachments must be base64-encoded. The maximum total request size is 250 MB.
+
+```perl
+use strict;
+use warnings;
+use Paubox_Forms_SDK;
+use MIME::Base64;
+
+my $forms = Paubox_Forms_SDK->new();
+
+open(my $fh, '<:raw', 'consent.pdf') or die "Cannot open file: $!";
+local $/;
+my $encoded = encode_base64(<$fh>);
+close($fh);
+
+my $response = $forms->submitForm(
+    "your-form-uuid",
+    { first_name => "Jane", signature => "{signature_field}" },
+    [ { name => "consent.pdf", content => $encoded } ]
+);
 ```
 
 <a name="#contributing"></a>

--- a/api.md
+++ b/api.md
@@ -1,0 +1,188 @@
+# Paubox Perl SDK — API Reference
+
+## Email API
+
+**Module:** `Paubox_Email_SDK`  
+**Base URL:** `https://api.paubox.net/v1/{apiUsername}`  
+**Authentication:** `Token token=<apiKey>` — credentials read from `config.cfg`
+
+---
+
+### `Paubox_Email_SDK->new()`
+
+Loads `apiKey` and `apiUsername` from `config.cfg` in the current working directory.
+
+```
+API_KEY = YOUR_API_KEY
+API_USERNAME = YOUR_ENDPOINT_NAME
+```
+
+Dies with an error message if either credential is missing.
+
+---
+
+### `$service->sendMessage($messageObj)`
+
+Sends a HIPAA-compliant email message.
+
+**Endpoint:** `POST /messages`
+
+**Parameter:** A `Paubox_Email_SDK::Message` object.
+
+| Message Field           | Type     | Required | Description                                        |
+|-------------------------|----------|----------|----------------------------------------------------|
+| `from`                  | String   | Yes      | Sender email address                               |
+| `to`                    | ArrayRef | Yes      | Array of recipient email addresses                 |
+| `subject`               | String   | Yes      | Email subject line                                 |
+| `text_content`          | String   | No       | Plain-text body                                    |
+| `html_content`          | String   | No       | HTML body (base64-encoded before transmission)     |
+| `replyTo`               | String   | No       | Reply-to address                                   |
+| `cc`                    | ArrayRef | No       | CC recipients                                      |
+| `bcc`                   | ArrayRef | No       | BCC recipients                                     |
+| `allowNonTLS`           | Boolean  | No       | `1` to allow delivery without TLS (default: `0`)  |
+| `forceSecureNotification` | String | No      | `"true"` or `"false"` to override org default     |
+| `attachments`           | ArrayRef | No       | Array of attachment hashrefs (see below)           |
+
+**Attachment hashref fields:**
+
+| Field         | Type   | Description                              |
+|---------------|--------|------------------------------------------|
+| `fileName`    | String | Filename shown to recipient              |
+| `contentType` | String | MIME type (e.g. `"application/pdf"`)     |
+| `content`     | String | Base64-encoded file content              |
+
+**Returns:** JSON string. On success, contains `data` and `sourceTrackingId`. On
+failure, contains `errors`.
+
+**Example:**
+
+```perl
+my $msg = new Paubox_Email_SDK::Message(
+    'from'         => 'sender@domain.com',
+    'to'           => ['recipient@example.com'],
+    'subject'      => 'Hello',
+    'text_content' => 'Hello World!',
+    'html_content' => '<html><body><h1>Hello World!</h1></body></html>',
+);
+
+my $service  = Paubox_Email_SDK->new();
+my $response = $service->sendMessage($msg);
+```
+
+---
+
+### `$service->getEmailDisposition($sourceTrackingId)`
+
+Retrieves delivery and open status for a previously sent message.
+
+**Endpoint:** `GET /message_receipt?sourceTrackingId={id}`
+
+**Parameter:** `$sourceTrackingId` — String returned by `sendMessage`.
+
+**Returns:** JSON string. On success, contains `data.message.message_deliveries`
+with per-recipient status. Unopened messages have `openedStatus` set to
+`"unopened"`. On failure, contains `errors`.
+
+**Example:**
+
+```perl
+my $service  = Paubox_Email_SDK->new();
+my $response = $service->getEmailDisposition("1aed91d1-f7ce-4c3d-8df2-85ecd225a7fc");
+```
+
+---
+
+## Forms API
+
+**Module:** `Paubox_Forms_SDK`  
+**Base URL:** `https://next.paubox.com`  
+**Authentication:** None — all Forms API endpoints are public.
+
+---
+
+### `Paubox_Forms_SDK->new()`
+
+Creates a new Forms client. No credentials or configuration file required.
+
+---
+
+### `$forms->getForm($formId)`
+
+Retrieves a form's metadata, HTML, JSON schema, and CSS by UUID.
+
+**Endpoint:** `GET /public/form_data/{formId}`
+
+**Parameter:** `$formId` — UUID string of the form to retrieve.
+
+**Returns:** JSON string containing form definition fields:
+
+| Field       | Type   | Description                              |
+|-------------|--------|------------------------------------------|
+| `id`        | String | Form UUID                                |
+| `title`     | String | Form title                               |
+| `form_html` | String | Rendered HTML of the form                |
+| `form_json` | Object | JSON schema of form fields               |
+| `form_css`  | String | CSS styles for the form                  |
+
+Dies if `formId` is empty or the response contains neither `id` nor `errors`.
+
+**Example:**
+
+```perl
+my $forms    = Paubox_Forms_SDK->new();
+my $response = $forms->getForm("your-form-uuid");
+```
+
+---
+
+### `$forms->submitForm($formId, \%formData [, \@attachments])`
+
+Submits a respondent's answers for a form, with optional file attachments.
+
+**Endpoint:** `POST /api/forms/{formId}/submissions`
+
+**Parameters:**
+
+| Parameter      | Type     | Required | Description                                        |
+|----------------|----------|----------|----------------------------------------------------|
+| `$formId`      | String   | Yes      | UUID of the target form                            |
+| `\%formData`   | HashRef  | Yes      | Key-value pairs matching the form's field schema   |
+| `\@attachments`| ArrayRef | No       | Array of attachment hashrefs (see below)           |
+
+**Attachment hashref fields:**
+
+| Field     | Type   | Description                    |
+|-----------|--------|--------------------------------|
+| `name`    | String | Filename                       |
+| `content` | String | Base64-encoded file content    |
+
+Maximum total request size: **250 MB**.
+
+**Returns:** Empty string on success (HTTP 201). Dies on error.
+
+**Example:**
+
+```perl
+my $forms    = Paubox_Forms_SDK->new();
+my $response = $forms->submitForm(
+    "your-form-uuid",
+    { first_name => "Jane", last_name => "Doe", email => "jane\@example.com" }
+);
+```
+
+**With attachment:**
+
+```perl
+use MIME::Base64;
+
+open(my $fh, '<:raw', 'consent.pdf') or die $!;
+local $/;
+my $encoded = encode_base64(<$fh>);
+close($fh);
+
+my $response = $forms->submitForm(
+    "your-form-uuid",
+    { first_name => "Jane" },
+    [ { name => "consent.pdf", content => $encoded } ]
+);
+```

--- a/api.md
+++ b/api.md
@@ -95,7 +95,7 @@ my $response = $service->getEmailDisposition("1aed91d1-f7ce-4c3d-8df2-85ecd225a7
 ## Forms API
 
 **Module:** `Paubox_Forms_SDK`  
-**Base URL:** `https://next.paubox.com`  
+**Base URL:** `https://apx.paubox.com/forms`  
 **Authentication:** None — all Forms API endpoints are public.
 
 ---

--- a/lib/Paubox_Email_SDK.pm
+++ b/lib/Paubox_Email_SDK.pm
@@ -12,7 +12,7 @@ our @EXPORT_OK = qw(
                           sendMessage                         
                   );
 
-our $VERSION = '1.2';
+our $VERSION = '1.3';
 
 use Paubox_Email_SDK::ApiHelper;
 use Paubox_Email_SDK::Message;

--- a/lib/Paubox_Email_SDK/ApiHelper.pm
+++ b/lib/Paubox_Email_SDK/ApiHelper.pm
@@ -8,10 +8,10 @@ our @ISA = qw(Exporter);
 
 our @EXPORT_OK = qw(
                           callToAPIByGet
-                          callToAPIByPost                         
+                          callToAPIByPost
                   );
 
-our $VERSION = '1.2';
+our $VERSION = '1.3';
 
 use REST::Client;
 use JSON;
@@ -32,7 +32,7 @@ sub callToAPIByGet {
     my $client = REST::Client -> new();
 
     $client -> addHeader('Content-Type', 'application/json');
-    $client -> addHeader('Authorization', $authHeader);
+    $client -> addHeader('Authorization', $authHeader) if $authHeader;
 
     $client -> setHost($baseUrl);
     $client -> GET(
@@ -48,14 +48,14 @@ sub callToAPIByPost {
     my $client = REST::Client -> new();
 
     $client -> addHeader('Content-Type', 'application/json');
-    $client -> addHeader('Authorization', $authHeader);
+    $client -> addHeader('Authorization', $authHeader) if $authHeader;
     $client -> addHeader('Accept', 'application/json');
 
     $client -> setHost($baseUrl);
     $client -> POST(
         $apiUrl,
         $reqBody
-    );    
+    );
     return $client -> responseContent();
 }
 

--- a/lib/Paubox_Email_SDK/Message.pm
+++ b/lib/Paubox_Email_SDK/Message.pm
@@ -3,7 +3,7 @@ package Paubox_Email_SDK::Message;
 use strict;
 use warnings;
 
-our $VERSION = '1.2';
+our $VERSION = '1.3';
 
 # constructor
 sub new {

--- a/lib/Paubox_Forms_SDK.pm
+++ b/lib/Paubox_Forms_SDK.pm
@@ -1,0 +1,157 @@
+package Paubox_Forms_SDK;
+
+use strict;
+use warnings;
+
+require Exporter;
+
+our @ISA = qw(Exporter);
+
+our @EXPORT_OK = qw(
+                          getForm
+                          submitForm
+                  );
+
+our $VERSION = '1.3';
+
+use Paubox_Email_SDK::ApiHelper;
+
+use JSON;
+use TryCatch;
+
+my $formsBaseURL = 'https://next.paubox.com';
+
+#
+# Default Constructor (no credentials required — Forms API is public)
+#
+sub new {
+    my $this = {};
+    bless $this;
+    return $this;
+}
+
+#
+# Public methods
+#
+
+#
+# Get Form
+# Retrieves a form's metadata, HTML, JSON schema, and CSS by UUID.
+#
+sub getForm {
+    my ($class, $formId) = @_;
+    my $apiResponseJSON = "";
+    try {
+        if ( !defined($formId) || $formId eq "" ) {
+            die "formId is required.";
+        }
+
+        my $apiUrl = "/public/form_data/" . $formId;
+        my $apiHelper = Paubox_Email_SDK::ApiHelper->new();
+        $apiResponseJSON = $apiHelper->callToAPIByGet($formsBaseURL, $apiUrl, "");
+
+        my $apiResponsePERL = from_json($apiResponseJSON);
+
+        if (
+            !defined $apiResponsePERL->{'id'}
+            && !defined $apiResponsePERL->{'errors'}
+        ) {
+            die $apiResponseJSON;
+        }
+
+    } catch($err) {
+        die $err;
+    };
+
+    return $apiResponseJSON;
+}
+
+#
+# Submit Form
+# Submits form responses with optional file attachments.
+# $formData  - hashref of field key/value pairs matching the form schema
+# $attachments - optional arrayref of hashrefs with 'name' and 'content' (base64)
+#
+sub submitForm {
+    my ($class, $formId, $formData, $attachments) = @_;
+    my $apiResponseJSON = "";
+    try {
+        if ( !defined($formId) || $formId eq "" ) {
+            die "formId is required.";
+        }
+
+        if ( !defined($formData) || ref($formData) ne 'HASH' || !%{$formData} ) {
+            die "formData is required and must be a non-empty hash reference.";
+        }
+
+        my $apiUrl = "/api/forms/" . $formId . "/submissions";
+
+        my %payload = ( 'form_data' => $formData );
+        if ( defined($attachments) && ref($attachments) eq 'ARRAY' && @{$attachments} ) {
+            $payload{'attachments'} = $attachments;
+        }
+
+        my $reqBody = encode_json(\%payload);
+        my $apiHelper = Paubox_Email_SDK::ApiHelper->new();
+        $apiResponseJSON = $apiHelper->callToAPIByPost($formsBaseURL, $apiUrl, "", $reqBody);
+
+        # 201 Created returns an empty body; treat that as success
+        if ( defined($apiResponseJSON) && $apiResponseJSON ne "" ) {
+            my $apiResponsePERL = from_json($apiResponseJSON);
+            if ( defined $apiResponsePERL->{'errors'} ) {
+                die $apiResponseJSON;
+            }
+        }
+
+    } catch($err) {
+        die $err;
+    };
+
+    return $apiResponseJSON;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Paubox_Forms_SDK - Perl wrapper for the Paubox Forms API (https://www.paubox.com/products/paubox-forms).
+
+=head1 SYNOPSIS
+
+    use strict;
+    use warnings;
+    use Paubox_Forms_SDK;
+
+    my $forms = Paubox_Forms_SDK->new();
+
+    # Retrieve a form definition
+    my $form = $forms->getForm("your-form-uuid");
+    print $form;
+
+    # Submit a form response
+    my $response = $forms->submitForm(
+        "your-form-uuid",
+        { first_name => "Jane", last_name => "Doe", email => "jane\@example.com" }
+    );
+
+=head1 DESCRIPTION
+
+This is the official Perl wrapper for the Paubox Forms API. The Forms API endpoints
+are public — no API key or credentials are required.
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2024 by Paubox Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut

--- a/lib/Paubox_Forms_SDK.pm
+++ b/lib/Paubox_Forms_SDK.pm
@@ -19,7 +19,7 @@ use Paubox_Email_SDK::ApiHelper;
 use JSON;
 use TryCatch;
 
-my $formsBaseURL = 'https://next.paubox.com';
+my $formsBaseURL = 'https://apx.paubox.com/forms';
 
 #
 # Default Constructor (no credentials required — Forms API is public)

--- a/t/lib/Paubox_Forms_SDK/Test.pm
+++ b/t/lib/Paubox_Forms_SDK/Test.pm
@@ -1,0 +1,100 @@
+package Paubox_Forms_SDK::Test;
+use strict;
+use warnings;
+
+use Paubox_Forms_SDK;
+
+use JSON;
+use Test::More;
+use base qw(Test::Class);
+
+# Replace with a real form UUID from your Paubox account to run live tests.
+my $VALID_FORM_UUID   = "your-valid-form-uuid-here";
+my $INVALID_FORM_UUID = "00000000-0000-0000-0000-000000000000";
+
+sub getForm_Success: Tests(1) {
+    print "Executing tests for getForm_Success:\n";
+
+    my $forms = Paubox_Forms_SDK->new();
+    my $response = eval { $forms->getForm($VALID_FORM_UUID) };
+
+    if ($@) {
+        is('Failure', 'Success', 'Test failed: ' . $@);
+        return;
+    }
+
+    my $apiResponsePERL = from_json($response);
+
+    if ( defined $apiResponsePERL->{'id'} ) {
+        is('Success', 'Success', 'Test passed');
+    } else {
+        is('Failure', 'Success', 'Test failed: id not present in response');
+    }
+}
+
+sub getForm_Failure: Tests(1) {
+    print "Executing tests for getForm_Failure:\n";
+
+    my $forms = Paubox_Forms_SDK->new();
+    my $response = eval { $forms->getForm($INVALID_FORM_UUID) };
+
+    if ($@) {
+        # A die on error is also acceptable as failure behaviour
+        is('Success', 'Success', 'Test passed: got expected error');
+        return;
+    }
+
+    my $apiResponsePERL = from_json($response);
+
+    if ( defined $apiResponsePERL->{'errors'} || !defined $apiResponsePERL->{'id'} ) {
+        is('Success', 'Success', 'Test passed');
+    } else {
+        is('Failure', 'Success', 'Test failed: expected error but got success');
+    }
+}
+
+sub submitForm_Success: Tests(1) {
+    print "Executing tests for submitForm_Success:\n";
+
+    my $forms = Paubox_Forms_SDK->new();
+    my $response = eval {
+        $forms->submitForm(
+            $VALID_FORM_UUID,
+            { first_name => "Jane", last_name => "Doe", email => "jane\@example.com" }
+        );
+    };
+
+    if ($@) {
+        is('Failure', 'Success', 'Test failed: ' . $@);
+        return;
+    }
+
+    # 201 returns empty body; empty string or no errors both indicate success
+    if ( !defined($response) || $response eq "" ) {
+        is('Success', 'Success', 'Test passed: 201 empty body');
+    } else {
+        my $apiResponsePERL = from_json($response);
+        if ( !defined $apiResponsePERL->{'errors'} ) {
+            is('Success', 'Success', 'Test passed');
+        } else {
+            is('Failure', 'Success', 'Test failed: ' . $response);
+        }
+    }
+}
+
+sub submitForm_Failure: Tests(1) {
+    print "Executing tests for submitForm_Failure:\n";
+
+    my $forms = Paubox_Forms_SDK->new();
+
+    # Missing formId should die
+    my $response = eval { $forms->getForm("") };
+
+    if ($@) {
+        is('Success', 'Success', 'Test passed: got expected error for empty formId');
+    } else {
+        is('Failure', 'Success', 'Test failed: expected error for empty formId');
+    }
+}
+
+1;


### PR DESCRIPTION
- Add lib/Paubox_Forms_SDK.pm with getForm and submitForm methods for
  the public Forms API (no credentials required).
- Update ApiHelper to conditionally set Authorization header, enabling
  use with unauthenticated endpoints.
- Add t/lib/Paubox_Forms_SDK/Test.pm with four test cases.
- Create api.md with full API reference for both Email and Forms APIs.
- Create CLAUDE.md with repo structure, setup, and architecture notes.
- Update README.md with Forms API usage examples.
- Bump all module versions to 1.3.

https://claude.ai/code/session_01QPRUUdS73LGGsYHG5cFkjv