### PR TITLE
Remove dead code: unused JSON import in ApiHelper

### DIFF
--- a/lib/Paubox_Email_SDK/ApiHelper.pm
+++ b/lib/Paubox_Email_SDK/ApiHelper.pm
@@ -14,7 +14,6 @@ our @EXPORT_OK = qw(
 our $VERSION = '1.3';
 
 use REST::Client;
-use JSON;
 
 #
 # Default Constructor


### PR DESCRIPTION
## Summary

Dead-code cleanup for the Paubox Perl SDK.

Removed the unused `use JSON;` import from `lib/Paubox_Email_SDK/ApiHelper.pm`. `ApiHelper` only wraps `REST::Client` and never calls any JSON function (`encode_json`/`decode_json`/etc.) — the import was dead and its removal has no functional effect.

## Scope notes

- Only truly dead code was removed. The `@EXPORT_OK` / Exporter declarations were intentionally left in place because they document the public API surface of a published SDK.
- Other observations found during analysis (an orphaned Forms test not wired into the runner, a stale `Paubox_Email_SDK-1.2.tar.gz` artifact referenced by the README, and some duplicate-code refactor candidates) were left as follow-ups rather than changed here.

## Verification

`perl -c` on the modified file fails only due to the missing `REST::Client` CPAN dependency in the CI-less sandbox, not any syntax error introduced by this change.

Slack thread: https://paubox.slack.com/archives/GNA4M3X9A/p1785430906909829

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2mk8w7VSmUuWQLum3yotp)_